### PR TITLE
Add Upgrade support to MSI (wxs)

### DIFF
--- a/wxs/auto_ossec.wxs
+++ b/wxs/auto_ossec.wxs
@@ -10,7 +10,7 @@
     >
 
         <Package
-            Description="Binary Defense Systems, Auto OSSEC"
+            Description='Binary Defense Systems, Auto OSSEC'
             Compressed='yes'
             Id='*'
             InstallerVersion='300'
@@ -18,9 +18,9 @@
             Platform='x86'
         />
 
-        <Property Id="MSIUSEREALADMINDETECTION" Value="1" />
-        <Property Id="ARPNOREPAIR" Value="1" />
-        <Property Id="ARPNOMODIFY" Value="1" />
+        <Property Id='MSIUSEREALADMINDETECTION' Value='1' />
+        <Property Id='ARPNOREPAIR' Value='1' />
+        <Property Id='ARPNOMODIFY' Value='1' />
 
         <Media
             Cabinet='AutoOSSEC.cab'
@@ -48,21 +48,21 @@
             </Directory>
         </Directory>
 
-        <Feature Id='Complete' Level="1">
+        <Feature Id='Complete' Level='1'>
             <ComponentRef Id='COMPAUTOOSSEC' />
         </Feature>
 
         <CustomAction
-            Id="EXECAUTOOSSEC"
-            Execute="deferred"
-            Impersonate="no"
-            ExeCommand="$(var.ServerAddress)"
-            FileKey="AUTOOSSECBINARY"
-            Return="check"
+            Id='EXECAUTOOSSEC'
+            Execute='deferred'
+            Impersonate='no'
+            ExeCommand='$(var.ServerAddress)'
+            FileKey='AUTOOSSECBINARY'
+            Return='check'
         />
 
         <InstallExecuteSequence>
-            <Custom Action="EXECAUTOOSSEC" After="InstallExecute" />
+            <Custom Action='EXECAUTOOSSEC' After='InstallExecute' />
         </InstallExecuteSequence>
     </Product>
 </Wix>

--- a/wxs/auto_ossec.wxs
+++ b/wxs/auto_ossec.wxs
@@ -1,12 +1,17 @@
 <?xml version='1.0' encoding='windows-1252'?>
+
+<?define UpgradeCode='C90A53AC-3ED3-46A7-B718-701F20C5C68D' ?>
+<?define ProductVersion='1.2.0' ?>
+<?define RTMVersion='1.0.0' ?>
+
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
     <Product
-        Id='CF0B24A8-1E99-4D5D-8DB4-005CE796448C'
+        Id='*'
         Language='1033'
         Manufacturer='Binary Defense Systems'
         Name='Auto OSSEC'
-        UpgradeCode='C90A53AC-3ED3-46A7-B718-701F20C5C68D'
-        Version='1.2.0.0'
+        UpgradeCode='$(var.UpgradeCode)'
+        Version='$(var.ProductVersion)'
     >
 
         <Package

--- a/wxs/auto_ossec.wxs
+++ b/wxs/auto_ossec.wxs
@@ -33,6 +33,24 @@
             Id='1'
         />
 
+        <Upgrade Id='$(var.UpgradeCode)'>
+            <UpgradeVersion
+                Minimum='$(var.ProductVersion)'
+                IncludeMinimum='no'
+                OnlyDetect='yes'
+                Language='1033'
+                Property='NEWPRODUCTFOUND'
+            />
+            <UpgradeVersion
+                Minimum='$(var.RTMVersion)'
+                IncludeMinimum='yes'
+                Maximum='$(var.ProductVersion)'
+                IncludeMaximum='no'
+                Language='1033'
+                Property='UPGRADEFOUND'
+            />
+        </Upgrade>
+
         <Directory Id='TARGETDIR' Name='SourceDir'>
             <Directory Id='ProgramFilesFolder'>
                 <Directory Id='COMPANYDIRECTORY' Name='BinaryDefense'>
@@ -67,7 +85,10 @@
         />
 
         <InstallExecuteSequence>
-            <Custom Action='EXECAUTOOSSEC' After='InstallExecute' />
+            <RemoveExistingProducts After='InstallFinalize' />
+            <Custom Action='EXECAUTOOSSEC' After='InstallExecute'>
+                <![CDATA[NOT Installed AND NOT WIX_UPGRADE_DETECTED]]>
+            </Custom>
         </InstallExecuteSequence>
     </Product>
 </Wix>


### PR DESCRIPTION
This change addresses the use case of a user installing versions of Auto OSSEC overtop of each other. Upgrades should go cleanly and remove previous versions. It also introduces a bugfix so that the EXECAUTOOSEC Custom Action is ran at a time when it has the auto_ossec binary available.
